### PR TITLE
Update pre-commit hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,17 +10,17 @@ repos:
       - id: debug-statements
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.9.5
+    rev: v0.12.8
     hooks:
       - id: ruff
         args: [--fix]
       - id: ruff-format
   - repo: https://github.com/RobertCraigie/pyright-python
-    rev: v1.1.393
+    rev: v1.1.403
     hooks:
       - id: pyright
   - repo: https://gitlab.com/vojko.pribudic.foss/pre-commit-update
-    rev: v0.6.1
+    rev: v0.8.0
     hooks:
       - id: pre-commit-update
         args: []


### PR DESCRIPTION
Bump versions for ruff-pre-commit, pyright-python, and pre-commit-update hooks in .pre-commit-config.yaml to ensure latest features and fixes.