### PR TITLE
Set SKIP env var for pre-commit in CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,5 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: pre-commit/action@v3.0.1
+        env:
+          SKIP: pre-commit-update


### PR DESCRIPTION
Adds the SKIP environment variable to the pre-commit action in the test workflow, skipping the 'pre-commit-update' hook during CI runs.