### PR TITLE
Add PyO3 bindings for Php5Random and Php5MtRandom

### DIFF
--- a/python/rust_neotools/__init__.py
+++ b/python/rust_neotools/__init__.py
@@ -3,7 +3,7 @@ __author__ = "diceroll123"
 __license__ = "MIT"
 __copyright__ = "Copyright 2023-present diceroll123"
 
-from .rust_neotools import IslandMystic, Symol  # noqa: F401
+from .rust_neotools import IslandMystic, Php5MtRandom, Php5Random, Symol  # noqa: F401
 
 try:
     from importlib.metadata import version
@@ -14,5 +14,7 @@ except Exception:
 
 __all__ = (
     "IslandMystic",
+    "Php5MtRandom",
+    "Php5Random",
     "Symol",
 )

--- a/python/rust_neotools/rust_neotools.pyi
+++ b/python/rust_neotools/rust_neotools.pyi
@@ -29,3 +29,25 @@ class IslandMystic:
     ) -> datetime | None:
         """Brute forces all dates for the given username, for the language and step direction of time given."""
         ...
+
+class Php5Random:
+    """PHP5's `rand()`/`srand()` (on Linux, backed by glibc's `random()`)."""
+
+    def __init__(self, seed: int, /) -> None: ...
+    def rand(self) -> int:
+        """Returns the next random number in the sequence."""
+        ...
+    def rand_range(self, min: int, max: int, /) -> int:
+        """Returns the next random number in the sequence, scaled to the given range."""
+        ...
+
+class Php5MtRandom:
+    """PHP5's `mt_rand()`/`mt_srand()` (a genuine Mersenne Twister, MT19937)."""
+
+    def __init__(self, seed: int, /) -> None: ...
+    def rand(self) -> int:
+        """Returns the next random number in the sequence."""
+        ...
+    def rand_range(self, min: int, max: int, /) -> int:
+        """Returns the next random number in the sequence, scaled to the given range."""
+        ...

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod symol;
 use pyo3::prelude::*;
 
 use islandmystic::IslandMystic;
+use php5random::{PyPhp5MtRandom, PyPhp5Random};
 use symol::Symol;
 
 #[pymodule]
@@ -11,6 +12,8 @@ use symol::Symol;
 fn rust_neotools(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<IslandMystic>()?;
     m.add_class::<Symol>()?;
+    m.add_class::<PyPhp5Random>()?;
+    m.add_class::<PyPhp5MtRandom>()?;
 
     Ok(())
 }

--- a/src/php5random.rs
+++ b/src/php5random.rs
@@ -1,3 +1,5 @@
+use pyo3::prelude::*;
+
 pub struct Php5Random {
     r: Vec<u32>,
     k: usize,
@@ -49,28 +51,20 @@ impl Php5Random {
     }
 }
 
-// Not wired up to any caller yet - PyO3 bindings land in a follow-up change.
-#[allow(dead_code)]
 const MT_N: usize = 624;
-#[allow(dead_code)]
 const MT_M: usize = 397;
-#[allow(dead_code)]
 const MT_MATRIX_A: u32 = 0x9908b0df;
-#[allow(dead_code)]
 const MT_UPPER_MASK: u32 = 0x80000000;
-#[allow(dead_code)]
 const MT_LOWER_MASK: u32 = 0x7fffffff;
 
 /// PHP5's `mt_rand()`/`mt_srand()` - a genuine Mersenne Twister (MT19937),
 /// entirely separate from `Php5Random` above (which reimplements PHP5's
 /// plain `rand()`/`srand()`, backed on Linux by glibc's `random()`).
-#[allow(dead_code)]
 pub struct Php5MtRandom {
     mt: Vec<u32>,
     idx: usize,
 }
 
-#[allow(dead_code)]
 impl Php5MtRandom {
     pub fn new(seed: u32) -> Php5MtRandom {
         let mut mtr = Php5MtRandom {
@@ -135,6 +129,46 @@ impl Php5MtRandom {
     pub fn rand_range(&mut self, min: u32, max: u32) -> u32 {
         let n = self.rand();
         (min as f64 + ((max as f64 - min as f64 + 1.0) * (n as f64 / 2147483648_f64))) as u32
+    }
+}
+
+/// Python-exposed wrapper around `Php5Random` (PHP5's `rand()`/`srand()`).
+#[pyclass(name = "Php5Random")]
+pub struct PyPhp5Random(Php5Random);
+
+#[pymethods]
+impl PyPhp5Random {
+    #[new]
+    fn new(seed: u32) -> Self {
+        PyPhp5Random(Php5Random::new(seed))
+    }
+
+    fn rand(&mut self) -> u32 {
+        self.0.rand()
+    }
+
+    fn rand_range(&mut self, min: u32, max: u32) -> u32 {
+        self.0.rand_range(min, max)
+    }
+}
+
+/// Python-exposed wrapper around `Php5MtRandom` (PHP5's `mt_rand()`/`mt_srand()`).
+#[pyclass(name = "Php5MtRandom")]
+pub struct PyPhp5MtRandom(Php5MtRandom);
+
+#[pymethods]
+impl PyPhp5MtRandom {
+    #[new]
+    fn new(seed: u32) -> Self {
+        PyPhp5MtRandom(Php5MtRandom::new(seed))
+    }
+
+    fn rand(&mut self) -> u32 {
+        self.0.rand()
+    }
+
+    fn rand_range(&mut self, min: u32, max: u32) -> u32 {
+        self.0.rand_range(min, max)
     }
 }
 

--- a/tests/test_php5random.py
+++ b/tests/test_php5random.py
@@ -1,0 +1,33 @@
+from rust_neotools import Php5MtRandom, Php5Random
+
+
+def test_php5_random_seed_one() -> None:
+    r = Php5Random(1)
+    values = [r.rand() for _ in range(5)]
+    assert values == [1804289383, 846930886, 1681692777, 1714636915, 1957747793]
+
+
+def test_php5_random_seed_one_range() -> None:
+    r = Php5Random(1)
+    values = [r.rand_range(0, 100) for _ in range(5)]
+    assert values == [84, 39, 79, 80, 92]
+
+
+def test_php5_mt_random_seed_one() -> None:
+    r = Php5MtRandom(1)
+    values = [r.rand() for _ in range(5)]
+    assert values == [1244335972, 15217923, 1546885062, 2002651684, 2135443977]
+
+
+def test_php5_mt_random_seed_one_range() -> None:
+    r = Php5MtRandom(1)
+    values = [r.rand_range(0, 100) for _ in range(5)]
+    assert values == [58, 0, 72, 94, 100]
+
+
+def test_php5_mt_random_seed_forty_two_range() -> None:
+    # Verified against a real php5.6-cli binary:
+    # mt_srand(42); mt_rand(0,23).",".mt_rand(0,59) === "15,47"
+    r = Php5MtRandom(42)
+    assert r.rand_range(0, 23) == 15
+    assert r.rand_range(0, 59) == 47


### PR DESCRIPTION
Neither PHP5 RNG (rand()/srand() via Php5Random, mt_rand()/mt_srand()
via Php5MtRandom) was previously exposed to Python. Add pyclass
wrappers for both, register them in the extension module, and add
matching type stubs and tests.

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>